### PR TITLE
Add command and query buses for poker workflows

### DIFF
--- a/application/commands/command-bus.ts
+++ b/application/commands/command-bus.ts
@@ -1,0 +1,31 @@
+export interface Command<Result = unknown> {
+  readonly name: string
+}
+
+export interface CommandHandler<TCommand extends Command<Result>, Result> {
+  handle(command: TCommand): Promise<Result> | Result
+}
+
+export class CommandBus {
+  private handlers: Map<string, CommandHandler<Command, unknown>> = new Map()
+
+  register<TCommand extends Command<Result>, Result>(
+    commandName: TCommand["name"],
+    handler: CommandHandler<TCommand, Result>
+  ) {
+    this.handlers.set(commandName, handler as CommandHandler<Command, unknown>)
+  }
+
+  async execute<TCommand extends Command<Result>, Result>(
+    command: TCommand
+  ): Promise<Result> {
+    const handler = this.handlers.get(command.name)
+
+    if (!handler) {
+      throw new Error(`No command handler registered for ${command.name}`)
+    }
+
+    const result = await handler.handle(command)
+    return result as Result
+  }
+}

--- a/application/commands/create-game-command.ts
+++ b/application/commands/create-game-command.ts
@@ -1,0 +1,16 @@
+import { Command } from "./command-bus"
+
+export interface CreateGameCommandProps {
+  name: string
+  hostId: string
+  scheduledAt: string
+  tableCount: number
+  maxPlayersPerTable: number
+}
+
+export class CreateGameCommand implements Command {
+  static readonly commandName = "CreateGameCommand"
+  readonly name = CreateGameCommand.commandName
+
+  constructor(public readonly payload: CreateGameCommandProps) {}
+}

--- a/application/commands/handlers/create-game-handler.ts
+++ b/application/commands/handlers/create-game-handler.ts
@@ -1,0 +1,47 @@
+import { PokerGame, TableState } from "../../shared/models"
+import { CommandHandler } from "../command-bus"
+import { CreateGameCommand } from "../create-game-command"
+import { GameWriteRepository, IdGenerator } from "../ports"
+
+export class CreateGameHandler
+  implements CommandHandler<CreateGameCommand, PokerGame>
+{
+  constructor(
+    private readonly repository: GameWriteRepository,
+    private readonly idGenerator: IdGenerator
+  ) {}
+
+  async handle(command: CreateGameCommand): Promise<PokerGame> {
+    const gameId = this.idGenerator.nextId("game")
+    const tables: TableState[] = Array.from(
+      { length: command.payload.tableCount },
+      (_, index) => {
+        const tableId = this.idGenerator.nextId(`table-${index + 1}`)
+        return {
+          id: tableId,
+          gameId,
+          name: `Table ${index + 1}`,
+          maxPlayers: command.payload.maxPlayersPerTable,
+          players: [],
+          waitlist: [],
+        }
+      }
+    )
+
+    const game: PokerGame = {
+      id: gameId,
+      name: command.payload.name,
+      hostId: command.payload.hostId,
+      scheduledAt: command.payload.scheduledAt,
+      tableCount: command.payload.tableCount,
+      maxPlayersPerTable: command.payload.maxPlayersPerTable,
+      status: "pending",
+      tables,
+    }
+
+    await this.repository.create(game)
+    await Promise.all(tables.map((table) => this.repository.saveTable(table)))
+
+    return game
+  }
+}

--- a/application/commands/handlers/join-table-handler.ts
+++ b/application/commands/handlers/join-table-handler.ts
@@ -1,0 +1,22 @@
+import { CommandHandler } from "../command-bus"
+import { JoinTableCommand } from "../join-table-command"
+import { TableMembershipWriter } from "../ports"
+
+export class JoinTableHandler
+  implements CommandHandler<JoinTableCommand, { joined: boolean }>
+{
+  constructor(private readonly membershipWriter: TableMembershipWriter) {}
+
+  async handle(command: JoinTableCommand): Promise<{ joined: boolean }> {
+    const table = await this.membershipWriter.addPlayer(
+      command.payload.tableId,
+      command.payload.playerId
+    )
+
+    if (!table) {
+      return { joined: false }
+    }
+
+    return { joined: true }
+  }
+}

--- a/application/commands/index.ts
+++ b/application/commands/index.ts
@@ -1,0 +1,32 @@
+import { CommandBus } from "./command-bus"
+import { CreateGameCommand } from "./create-game-command"
+import { JoinTableCommand } from "./join-table-command"
+import { CreateGameHandler } from "./handlers/create-game-handler"
+import { JoinTableHandler } from "./handlers/join-table-handler"
+import {
+  GameWriteRepository,
+  IdGenerator,
+  TableMembershipWriter,
+} from "./ports"
+
+export interface CommandDependencies {
+  gameRepository: GameWriteRepository
+  tableMembershipWriter: TableMembershipWriter
+  idGenerator: IdGenerator
+}
+
+export function registerCommandHandlers(
+  commandBus: CommandBus,
+  dependencies: CommandDependencies
+) {
+  const createGameHandler = new CreateGameHandler(
+    dependencies.gameRepository,
+    dependencies.idGenerator
+  )
+  const joinTableHandler = new JoinTableHandler(
+    dependencies.tableMembershipWriter
+  )
+
+  commandBus.register(CreateGameCommand.commandName, createGameHandler)
+  commandBus.register(JoinTableCommand.commandName, joinTableHandler)
+}

--- a/application/commands/join-table-command.ts
+++ b/application/commands/join-table-command.ts
@@ -1,0 +1,13 @@
+import { Command } from "./command-bus"
+
+export interface JoinTableCommandProps {
+  tableId: string
+  playerId: string
+}
+
+export class JoinTableCommand implements Command {
+  static readonly commandName = "JoinTableCommand"
+  readonly name = JoinTableCommand.commandName
+
+  constructor(public readonly payload: JoinTableCommandProps) {}
+}

--- a/application/commands/ports.ts
+++ b/application/commands/ports.ts
@@ -1,0 +1,14 @@
+import { PokerGame, TableState } from "../shared/models"
+
+export interface IdGenerator {
+  nextId(prefix?: string): string
+}
+
+export interface GameWriteRepository {
+  create(game: PokerGame): Promise<void>
+  saveTable(table: TableState): Promise<void>
+}
+
+export interface TableMembershipWriter {
+  addPlayer(tableId: string, playerId: string): Promise<TableState | null>
+}

--- a/application/index.ts
+++ b/application/index.ts
@@ -1,0 +1,24 @@
+import { CommandBus } from "./commands/command-bus"
+import { registerCommandHandlers } from "./commands"
+import { QueryBus } from "./queries/query-bus"
+import { registerQueryHandlers } from "./queries"
+import { InMemoryIdGenerator, InMemoryPokerRepository } from "./state/in-memory-poker-repository"
+
+const commandBus = new CommandBus()
+const queryBus = new QueryBus()
+
+const repository = new InMemoryPokerRepository()
+const idGenerator = new InMemoryIdGenerator()
+
+registerCommandHandlers(commandBus, {
+  gameRepository: repository,
+  tableMembershipWriter: repository,
+  idGenerator,
+})
+
+registerQueryHandlers(queryBus, {
+  tableRepository: repository,
+  tournamentRepository: repository,
+})
+
+export { commandBus, queryBus, repository, idGenerator }

--- a/application/queries/get-table-state-query.ts
+++ b/application/queries/get-table-state-query.ts
@@ -1,0 +1,8 @@
+import { Query } from "./query-bus"
+
+export class GetTableStateQuery implements Query {
+  static readonly queryName = "GetTableStateQuery"
+  readonly name = GetTableStateQuery.queryName
+
+  constructor(public readonly tableId: string) {}
+}

--- a/application/queries/handlers/get-table-state-handler.ts
+++ b/application/queries/handlers/get-table-state-handler.ts
@@ -1,0 +1,14 @@
+import { TableState } from "../../shared/models"
+import { GetTableStateQuery } from "../get-table-state-query"
+import { TableReadRepository } from "../ports"
+import { QueryHandler } from "../query-bus"
+
+export class GetTableStateHandler
+  implements QueryHandler<GetTableStateQuery, TableState | null>
+{
+  constructor(private readonly tableRepository: TableReadRepository) {}
+
+  async execute(query: GetTableStateQuery): Promise<TableState | null> {
+    return this.tableRepository.getTable(query.tableId)
+  }
+}

--- a/application/queries/handlers/list-tournaments-handler.ts
+++ b/application/queries/handlers/list-tournaments-handler.ts
@@ -1,0 +1,14 @@
+import { TournamentSummary } from "../../shared/models"
+import { ListTournamentsQuery } from "../list-tournaments-query"
+import { TournamentReadRepository } from "../ports"
+import { QueryHandler } from "../query-bus"
+
+export class ListTournamentsHandler
+  implements QueryHandler<ListTournamentsQuery, TournamentSummary[]>
+{
+  constructor(private readonly tournamentRepository: TournamentReadRepository) {}
+
+  async execute(query: ListTournamentsQuery): Promise<TournamentSummary[]> {
+    return this.tournamentRepository.listTournaments(query.filter)
+  }
+}

--- a/application/queries/index.ts
+++ b/application/queries/index.ts
@@ -1,0 +1,26 @@
+import { GetTableStateHandler } from "./handlers/get-table-state-handler"
+import { ListTournamentsHandler } from "./handlers/list-tournaments-handler"
+import { GetTableStateQuery } from "./get-table-state-query"
+import { ListTournamentsQuery } from "./list-tournaments-query"
+import { TableReadRepository, TournamentReadRepository } from "./ports"
+import { QueryBus } from "./query-bus"
+
+export interface QueryDependencies {
+  tableRepository: TableReadRepository
+  tournamentRepository: TournamentReadRepository
+}
+
+export function registerQueryHandlers(
+  queryBus: QueryBus,
+  dependencies: QueryDependencies
+) {
+  const getTableStateHandler = new GetTableStateHandler(
+    dependencies.tableRepository
+  )
+  const listTournamentsHandler = new ListTournamentsHandler(
+    dependencies.tournamentRepository
+  )
+
+  queryBus.register(GetTableStateQuery.queryName, getTableStateHandler)
+  queryBus.register(ListTournamentsQuery.queryName, listTournamentsHandler)
+}

--- a/application/queries/list-tournaments-query.ts
+++ b/application/queries/list-tournaments-query.ts
@@ -1,0 +1,14 @@
+import { Query } from "./query-bus"
+
+export interface ListTournamentsFilter {
+  leagueId?: string
+  seriesId?: string
+  status?: "scheduled" | "active" | "completed"
+}
+
+export class ListTournamentsQuery implements Query {
+  static readonly queryName = "ListTournamentsQuery"
+  readonly name = ListTournamentsQuery.queryName
+
+  constructor(public readonly filter: ListTournamentsFilter = {}) {}
+}

--- a/application/queries/ports.ts
+++ b/application/queries/ports.ts
@@ -1,0 +1,11 @@
+import { TableState, TournamentSummary } from "../shared/models"
+
+export interface TableReadRepository {
+  getTable(tableId: string): Promise<TableState | null>
+}
+
+export interface TournamentReadRepository {
+  listTournaments(
+    filter?: Partial<Pick<TournamentSummary, "leagueId" | "seriesId" | "status">>
+  ): Promise<TournamentSummary[]>
+}

--- a/application/queries/query-bus.ts
+++ b/application/queries/query-bus.ts
@@ -1,0 +1,31 @@
+export interface Query<Result = unknown> {
+  readonly name: string
+}
+
+export interface QueryHandler<TQuery extends Query<Result>, Result> {
+  execute(query: TQuery): Promise<Result> | Result
+}
+
+export class QueryBus {
+  private handlers: Map<string, QueryHandler<Query, unknown>> = new Map()
+
+  register<TQuery extends Query<Result>, Result>(
+    queryName: TQuery["name"],
+    handler: QueryHandler<TQuery, Result>
+  ) {
+    this.handlers.set(queryName, handler as QueryHandler<Query, unknown>)
+  }
+
+  async execute<TQuery extends Query<Result>, Result>(
+    query: TQuery
+  ): Promise<Result> {
+    const handler = this.handlers.get(query.name)
+
+    if (!handler) {
+      throw new Error(`No query handler registered for ${query.name}`)
+    }
+
+    const result = await handler.execute(query)
+    return result as Result
+  }
+}

--- a/application/shared/models.ts
+++ b/application/shared/models.ts
@@ -1,0 +1,28 @@
+export interface PokerGame {
+  id: string
+  name: string
+  hostId: string
+  scheduledAt: string
+  tableCount: number
+  maxPlayersPerTable: number
+  status: "pending" | "active" | "completed"
+  tables: TableState[]
+}
+
+export interface TableState {
+  id: string
+  gameId: string
+  name: string
+  maxPlayers: number
+  players: string[]
+  waitlist: string[]
+}
+
+export interface TournamentSummary {
+  id: string
+  name: string
+  leagueId?: string
+  seriesId?: string
+  scheduledAt: string
+  status: "scheduled" | "active" | "completed"
+}

--- a/application/state/in-memory-poker-repository.ts
+++ b/application/state/in-memory-poker-repository.ts
@@ -1,0 +1,94 @@
+import { GameWriteRepository, IdGenerator, TableMembershipWriter } from "../commands/ports"
+import { TableReadRepository, TournamentReadRepository } from "../queries/ports"
+import { PokerGame, TableState, TournamentSummary } from "../shared/models"
+
+export class InMemoryIdGenerator implements IdGenerator {
+  private counter = 0
+
+  nextId(prefix = "id"): string {
+    this.counter += 1
+    return `${prefix}-${this.counter}`
+  }
+}
+
+export class InMemoryPokerRepository
+  implements
+    GameWriteRepository,
+    TableMembershipWriter,
+    TableReadRepository,
+    TournamentReadRepository
+{
+  private games = new Map<string, PokerGame>()
+  private tables = new Map<string, TableState>()
+  private tournaments = new Map<string, TournamentSummary>()
+
+  constructor(seed?: {
+    games?: PokerGame[]
+    tables?: TableState[]
+    tournaments?: TournamentSummary[]
+  }) {
+    seed?.games?.forEach((game) => this.games.set(game.id, game))
+    seed?.tables?.forEach((table) => this.tables.set(table.id, table))
+    seed?.tournaments?.forEach((tournament) =>
+      this.tournaments.set(tournament.id, tournament)
+    )
+  }
+
+  async create(game: PokerGame): Promise<void> {
+    this.games.set(game.id, game)
+  }
+
+  async saveTable(table: TableState): Promise<void> {
+    this.tables.set(table.id, table)
+  }
+
+  async addPlayer(
+    tableId: string,
+    playerId: string
+  ): Promise<TableState | null> {
+    const table = this.tables.get(tableId)
+
+    if (!table) {
+      return null
+    }
+
+    const hasSpace = table.players.length < table.maxPlayers
+
+    if (table.players.includes(playerId) || table.waitlist.includes(playerId)) {
+      return table
+    }
+
+    if (hasSpace) {
+      table.players = [...table.players, playerId]
+    } else {
+      table.waitlist = [...table.waitlist, playerId]
+    }
+
+    this.tables.set(tableId, { ...table })
+    return this.tables.get(tableId) ?? null
+  }
+
+  async getTable(tableId: string): Promise<TableState | null> {
+    return this.tables.get(tableId) ?? null
+  }
+
+  async listTournaments(filter = {}): Promise<TournamentSummary[]> {
+    const tournaments = Array.from(this.tournaments.values())
+
+    return tournaments.filter((tournament) => {
+      if (filter.leagueId && tournament.leagueId !== filter.leagueId) {
+        return false
+      }
+
+      if (filter.seriesId && tournament.seriesId !== filter.seriesId) {
+        return false
+      }
+
+      if (filter.status && tournament.status !== filter.status) {
+        return false
+      }
+
+      return true
+    })
+  }
+}


### PR DESCRIPTION
## Summary
- organize application layer into commands and queries with dedicated buses
- add DTOs and handlers for creating games, joining tables, retrieving table state, and listing tournaments
- provide in-memory infrastructure and registration helpers to wire command and query pipelines separately

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694239f50f388322b42dd8868a9c2e0d)