### PR TITLE
Add onion-structured Terraform IaC for Proxmox Ubuntu VM and nightly snapshots

### DIFF
--- a/iac/README.md
+++ b/iac/README.md
@@ -1,0 +1,67 @@
+# Proxmox IaC Stack (Ubuntu VM + Nightly Snapshots)
+
+This folder contains a complete Terraform/OpenTofu Infrastructure-as-Code stack for:
+
+- Managing a Proxmox VE node.
+- Provisioning one Ubuntu VM from a cloud image template.
+- Enforcing a nightly snapshot policy on that VM.
+
+The codebase is structured with an onion-architecture-inspired layering model:
+
+- **Domain layer**: pure configuration contract + validation.
+- **Application layer**: orchestration and use-case composition.
+- **Infrastructure layer**: provider-specific Proxmox and host automation resources.
+
+## Architecture
+
+```text
+iac/
+├── main.tf                          # composition root
+├── providers.tf                     # providers + auth wiring
+├── variables.tf                     # root input contract
+├── outputs.tf                       # root outputs
+├── versions.tf                      # Terraform & provider versions
+├── terraform.tfvars.example         # starter variables
+└── modules
+    ├── domain-vm-contract           # domain layer
+    ├── application/proxmox-node-stack
+    └── infrastructure
+        ├── proxmox-ubuntu-vm
+        └── nightly-snapshot-cron
+```
+
+## Prerequisites
+
+1. Proxmox VE node reachable from the machine running Terraform.
+2. API token created in Proxmox (`Datastore.AllocateSpace`, `VM.Allocate`, `VM.Config.*`, `VM.Snapshot`).
+3. Ubuntu cloud image template already available in Proxmox.
+4. SSH access from Terraform runner to Proxmox host (for cron-based nightly snapshots).
+
+## Quick start
+
+```bash
+cd iac
+cp terraform.tfvars.example terraform.tfvars
+# edit terraform.tfvars with your node/template/network details
+terraform init
+terraform plan
+terraform apply
+```
+
+## Nightly snapshots design
+
+The stack writes a cron entry on the Proxmox node that executes:
+
+```bash
+qm snapshot <vmid> nightly-YYYYMMDD-HHMM --description "nightly snapshot via terraform"
+```
+
+at the configured UTC time.
+
+Retention is enforced in the same cron line by pruning older `nightly-*` snapshots, keeping `snapshot_retention` most recent entries.
+
+## Notes
+
+- Snapshot schedule runs on **UTC** by default for predictability.
+- If you prefer Proxmox backup jobs instead of snapshots, add a dedicated backup module and disable the cron module.
+- Use a dedicated automation account on the Proxmox host for SSH provisioning.

--- a/iac/README.md
+++ b/iac/README.md
@@ -1,16 +1,17 @@
-# Proxmox IaC Stack (Ubuntu VM + Nightly Snapshots)
+# Proxmox IaC Stack (Ubuntu Template + VM + Nightly Snapshots)
 
 This folder contains a complete Terraform/OpenTofu Infrastructure-as-Code stack for:
 
 - Managing a Proxmox VE node.
-- Provisioning one Ubuntu VM from a cloud image template.
+- Creating/updating an Ubuntu cloud image template in Proxmox.
+- Provisioning one Ubuntu VM cloned from that template.
 - Enforcing a nightly snapshot policy on that VM.
 
 The codebase is structured with an onion-architecture-inspired layering model:
 
-- **Domain layer**: pure configuration contract + validation.
+- **Domain layer**: pure configuration contracts + validation.
 - **Application layer**: orchestration and use-case composition.
-- **Infrastructure layer**: provider-specific Proxmox and host automation resources.
+- **Infrastructure layer**: provider-specific Proxmox and node automation resources.
 
 ## Architecture
 
@@ -26,6 +27,7 @@ iac/
     ├── domain-vm-contract           # domain layer
     ├── application/proxmox-node-stack
     └── infrastructure
+        ├── ubuntu-cloud-template
         ├── proxmox-ubuntu-vm
         └── nightly-snapshot-cron
 ```
@@ -34,8 +36,7 @@ iac/
 
 1. Proxmox VE node reachable from the machine running Terraform.
 2. API token created in Proxmox (`Datastore.AllocateSpace`, `VM.Allocate`, `VM.Config.*`, `VM.Snapshot`).
-3. Ubuntu cloud image template already available in Proxmox.
-4. SSH access from Terraform runner to Proxmox host (for cron-based nightly snapshots).
+3. SSH access from Terraform runner to Proxmox host (for template prep and cron-based nightly snapshots).
 
 ## Quick start
 
@@ -48,20 +49,22 @@ terraform plan
 terraform apply
 ```
 
+## Ubuntu template management
+
+When `ubuntu_template.enabled = true`, the stack will:
+
+1. Download/update the Ubuntu cloud image on the Proxmox host.
+2. Create template VM (if missing) with cloud-init settings.
+3. Convert that VM to a Proxmox template.
+4. Clone the workload VM from that template.
+
+When `ubuntu_template.enabled = false`, VM cloning uses `vm.template` as provided.
+
 ## Nightly snapshots design
 
-The stack writes a cron entry on the Proxmox node that executes:
-
-```bash
-qm snapshot <vmid> nightly-YYYYMMDD-HHMM --description "nightly snapshot via terraform"
-```
-
-at the configured UTC time.
-
-Retention is enforced in the same cron line by pruning older `nightly-*` snapshots, keeping `snapshot_retention` most recent entries.
+The stack writes a cron entry on the Proxmox node that executes `qm snapshot` nightly and prunes old snapshots based on retention.
 
 ## Notes
 
 - Snapshot schedule runs on **UTC** by default for predictability.
-- If you prefer Proxmox backup jobs instead of snapshots, add a dedicated backup module and disable the cron module.
-- Use a dedicated automation account on the Proxmox host for SSH provisioning.
+- Use dedicated automation SSH credentials for template bootstrap and snapshot cron management.

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -1,0 +1,8 @@
+module "proxmox_node_stack" {
+  source = "./modules/application/proxmox-node-stack"
+
+  node_name = var.node_name
+  vm        = var.vm
+
+  snapshot_schedule = var.snapshot_schedule
+}

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -2,7 +2,8 @@ module "proxmox_node_stack" {
   source = "./modules/application/proxmox-node-stack"
 
   node_name = var.node_name
-  vm        = var.vm
+  vm              = var.vm
+  ubuntu_template = var.ubuntu_template
 
   snapshot_schedule = var.snapshot_schedule
 }

--- a/iac/modules/application/proxmox-node-stack/main.tf
+++ b/iac/modules/application/proxmox-node-stack/main.tf
@@ -1,0 +1,49 @@
+module "domain_contract" {
+  source = "../../domain-vm-contract"
+
+  node_name         = var.node_name
+  vm                = var.vm
+  snapshot_schedule = var.snapshot_schedule
+}
+
+module "ubuntu_vm" {
+  source = "../../infrastructure/proxmox-ubuntu-vm"
+
+  node_name      = module.domain_contract.vm_contract.node_name
+  vm_id          = module.domain_contract.vm_contract.vm_id
+  vm_name        = module.domain_contract.vm_contract.vm_name
+  template       = module.domain_contract.vm_contract.template
+  cpu_cores      = module.domain_contract.vm_contract.cpu_cores
+  cpu_sockets    = module.domain_contract.vm_contract.cpu_sockets
+  memory_mb      = module.domain_contract.vm_contract.memory_mb
+  disk_gb        = module.domain_contract.vm_contract.disk_gb
+  storage_pool   = module.domain_contract.vm_contract.storage_pool
+  bridge         = module.domain_contract.vm_contract.bridge
+  ci_user        = module.domain_contract.vm_contract.ci_user
+  ssh_public_key = module.domain_contract.vm_contract.ssh_public_key
+  ipconfig0      = module.domain_contract.vm_contract.ipconfig0
+  nameserver     = module.domain_contract.vm_contract.nameserver
+  search_domain  = module.domain_contract.vm_contract.search_domain
+  balloon_mb     = module.domain_contract.vm_contract.balloon_mb
+  start_on_boot  = module.domain_contract.vm_contract.start_on_boot
+  agent_enabled  = module.domain_contract.vm_contract.agent_enabled
+}
+
+module "nightly_snapshot_cron" {
+  source = "../../infrastructure/nightly-snapshot-cron"
+
+  enabled          = module.domain_contract.snapshot_contract.enabled
+  minute           = module.domain_contract.snapshot_contract.minute
+  hour             = module.domain_contract.snapshot_contract.hour
+  retention        = module.domain_contract.snapshot_contract.retention
+  vm_id            = module.ubuntu_vm.vm_id
+  ssh_host         = module.domain_contract.snapshot_contract.ssh_host
+  ssh_port         = module.domain_contract.snapshot_contract.ssh_port
+  ssh_user         = module.domain_contract.snapshot_contract.ssh_user
+  ssh_private_key  = module.domain_contract.snapshot_contract.ssh_private_key
+  cron_identifier  = module.domain_contract.snapshot_contract.cron_identifier
+  snapshot_prefix  = module.domain_contract.snapshot_contract.snapshot_prefix
+  snapshot_comment = module.domain_contract.snapshot_contract.snapshot_comment
+
+  depends_on = [module.ubuntu_vm]
+}

--- a/iac/modules/application/proxmox-node-stack/main.tf
+++ b/iac/modules/application/proxmox-node-stack/main.tf
@@ -3,7 +3,29 @@ module "domain_contract" {
 
   node_name         = var.node_name
   vm                = var.vm
+  ubuntu_template   = var.ubuntu_template
   snapshot_schedule = var.snapshot_schedule
+}
+
+module "ubuntu_cloud_template" {
+  source = "../../infrastructure/ubuntu-cloud-template"
+
+  enabled          = module.domain_contract.ubuntu_template_contract.enabled
+  node_name        = module.domain_contract.vm_contract.node_name
+  template_vmid    = module.domain_contract.ubuntu_template_contract.vmid
+  template_name    = module.domain_contract.ubuntu_template_contract.name
+  storage_pool     = module.domain_contract.ubuntu_template_contract.storage_pool
+  snippets_storage = module.domain_contract.ubuntu_template_contract.snippets_storage
+  cloud_image_url  = module.domain_contract.ubuntu_template_contract.cloud_image_url
+  ci_user          = module.domain_contract.ubuntu_template_contract.ci_user
+  ssh_public_key   = module.domain_contract.ubuntu_template_contract.ssh_public_key
+  memory_mb        = module.domain_contract.ubuntu_template_contract.memory_mb
+  cpu_cores        = module.domain_contract.ubuntu_template_contract.cpu_cores
+  cpu_sockets      = module.domain_contract.ubuntu_template_contract.cpu_sockets
+  ssh_host         = module.domain_contract.ubuntu_template_contract.ssh_host
+  ssh_port         = module.domain_contract.ubuntu_template_contract.ssh_port
+  ssh_user         = module.domain_contract.ubuntu_template_contract.ssh_user
+  ssh_private_key  = module.domain_contract.ubuntu_template_contract.ssh_private_key
 }
 
 module "ubuntu_vm" {
@@ -27,6 +49,8 @@ module "ubuntu_vm" {
   balloon_mb     = module.domain_contract.vm_contract.balloon_mb
   start_on_boot  = module.domain_contract.vm_contract.start_on_boot
   agent_enabled  = module.domain_contract.vm_contract.agent_enabled
+
+  depends_on = [module.ubuntu_cloud_template]
 }
 
 module "nightly_snapshot_cron" {

--- a/iac/modules/application/proxmox-node-stack/outputs.tf
+++ b/iac/modules/application/proxmox-node-stack/outputs.tf
@@ -1,3 +1,11 @@
+output "template_managed" {
+  value = module.ubuntu_cloud_template.managed
+}
+
+output "template_name" {
+  value = module.ubuntu_cloud_template.template_name
+}
+
 output "vm_id" {
   value = module.ubuntu_vm.vm_id
 }

--- a/iac/modules/application/proxmox-node-stack/outputs.tf
+++ b/iac/modules/application/proxmox-node-stack/outputs.tf
@@ -1,0 +1,11 @@
+output "vm_id" {
+  value = module.ubuntu_vm.vm_id
+}
+
+output "vm_name" {
+  value = module.ubuntu_vm.vm_name
+}
+
+output "snapshot_cron_installed" {
+  value = module.nightly_snapshot_cron.installed
+}

--- a/iac/modules/application/proxmox-node-stack/variables.tf
+++ b/iac/modules/application/proxmox-node-stack/variables.tf
@@ -1,0 +1,42 @@
+variable "node_name" {
+  type = string
+}
+
+variable "vm" {
+  type = object({
+    id               = number
+    name             = string
+    template         = string
+    cpu_cores        = number
+    cpu_sockets      = number
+    memory_mb        = number
+    disk_gb          = number
+    storage_pool     = string
+    bridge           = string
+    ip_cidr          = string
+    gateway          = string
+    ci_user          = string
+    ssh_public_key   = string
+    search_domain    = optional(string)
+    nameserver       = optional(string)
+    balloon_mb       = optional(number)
+    start_on_boot    = optional(bool)
+    agent_enabled    = optional(bool)
+  })
+}
+
+variable "snapshot_schedule" {
+  type = object({
+    enabled           = bool
+    minute            = number
+    hour              = number
+    retention         = number
+    ssh_host          = string
+    ssh_port          = optional(number)
+    ssh_user          = string
+    ssh_private_key   = string
+    cron_identifier   = optional(string)
+    snapshot_prefix   = optional(string)
+    snapshot_comment  = optional(string)
+  })
+}

--- a/iac/modules/application/proxmox-node-stack/variables.tf
+++ b/iac/modules/application/proxmox-node-stack/variables.tf
@@ -40,3 +40,24 @@ variable "snapshot_schedule" {
     snapshot_comment  = optional(string)
   })
 }
+
+
+variable "ubuntu_template" {
+  type = object({
+    enabled          = bool
+    vmid             = number
+    name             = string
+    storage_pool     = string
+    snippets_storage = optional(string)
+    cloud_image_url  = string
+    ci_user          = string
+    ssh_public_key   = string
+    memory_mb        = optional(number)
+    cpu_cores        = optional(number)
+    cpu_sockets      = optional(number)
+    ssh_host         = string
+    ssh_port         = optional(number)
+    ssh_user         = string
+    ssh_private_key  = string
+  })
+}

--- a/iac/modules/domain-vm-contract/main.tf
+++ b/iac/modules/domain-vm-contract/main.tf
@@ -1,0 +1,36 @@
+locals {
+  vm_contract = {
+    node_name      = var.node_name
+    vm_id          = var.vm.id
+    vm_name        = var.vm.name
+    template       = var.vm.template
+    cpu_cores      = var.vm.cpu_cores
+    cpu_sockets    = var.vm.cpu_sockets
+    memory_mb      = var.vm.memory_mb
+    disk_gb        = var.vm.disk_gb
+    storage_pool   = var.vm.storage_pool
+    bridge         = var.vm.bridge
+    ci_user        = var.vm.ci_user
+    ssh_public_key = var.vm.ssh_public_key
+    ipconfig0      = "ip=${var.vm.ip_cidr},gw=${var.vm.gateway}"
+    nameserver     = try(var.vm.nameserver, null)
+    search_domain  = try(var.vm.search_domain, null)
+    balloon_mb     = try(var.vm.balloon_mb, 0)
+    start_on_boot  = try(var.vm.start_on_boot, true)
+    agent_enabled  = try(var.vm.agent_enabled, true)
+  }
+
+  snapshot_contract = {
+    enabled          = var.snapshot_schedule.enabled
+    minute           = var.snapshot_schedule.minute
+    hour             = var.snapshot_schedule.hour
+    retention        = var.snapshot_schedule.retention
+    ssh_host         = var.snapshot_schedule.ssh_host
+    ssh_port         = try(var.snapshot_schedule.ssh_port, 22)
+    ssh_user         = var.snapshot_schedule.ssh_user
+    ssh_private_key  = var.snapshot_schedule.ssh_private_key
+    cron_identifier  = try(var.snapshot_schedule.cron_identifier, "nightly-vm-snapshot")
+    snapshot_prefix  = try(var.snapshot_schedule.snapshot_prefix, "nightly")
+    snapshot_comment = try(var.snapshot_schedule.snapshot_comment, "nightly snapshot via terraform")
+  }
+}

--- a/iac/modules/domain-vm-contract/main.tf
+++ b/iac/modules/domain-vm-contract/main.tf
@@ -1,9 +1,27 @@
 locals {
+  ubuntu_template_contract = {
+    enabled          = var.ubuntu_template.enabled
+    vmid             = var.ubuntu_template.vmid
+    name             = var.ubuntu_template.name
+    storage_pool     = var.ubuntu_template.storage_pool
+    snippets_storage = try(var.ubuntu_template.snippets_storage, var.ubuntu_template.storage_pool)
+    cloud_image_url  = var.ubuntu_template.cloud_image_url
+    ci_user          = var.ubuntu_template.ci_user
+    ssh_public_key   = var.ubuntu_template.ssh_public_key
+    memory_mb        = try(var.ubuntu_template.memory_mb, 2048)
+    cpu_cores        = try(var.ubuntu_template.cpu_cores, 2)
+    cpu_sockets      = try(var.ubuntu_template.cpu_sockets, 1)
+    ssh_host         = var.ubuntu_template.ssh_host
+    ssh_port         = try(var.ubuntu_template.ssh_port, 22)
+    ssh_user         = var.ubuntu_template.ssh_user
+    ssh_private_key  = var.ubuntu_template.ssh_private_key
+  }
+
   vm_contract = {
     node_name      = var.node_name
     vm_id          = var.vm.id
     vm_name        = var.vm.name
-    template       = var.vm.template
+    template       = local.ubuntu_template_contract.enabled ? local.ubuntu_template_contract.name : var.vm.template
     cpu_cores      = var.vm.cpu_cores
     cpu_sockets    = var.vm.cpu_sockets
     memory_mb      = var.vm.memory_mb

--- a/iac/modules/domain-vm-contract/outputs.tf
+++ b/iac/modules/domain-vm-contract/outputs.tf
@@ -1,0 +1,7 @@
+output "vm_contract" {
+  value = local.vm_contract
+}
+
+output "snapshot_contract" {
+  value = local.snapshot_contract
+}

--- a/iac/modules/domain-vm-contract/outputs.tf
+++ b/iac/modules/domain-vm-contract/outputs.tf
@@ -1,3 +1,7 @@
+output "ubuntu_template_contract" {
+  value = local.ubuntu_template_contract
+}
+
 output "vm_contract" {
   value = local.vm_contract
 }

--- a/iac/modules/domain-vm-contract/variables.tf
+++ b/iac/modules/domain-vm-contract/variables.tf
@@ -1,0 +1,82 @@
+variable "node_name" {
+  type = string
+}
+
+variable "vm" {
+  type = object({
+    id               = number
+    name             = string
+    template         = string
+    cpu_cores        = number
+    cpu_sockets      = number
+    memory_mb        = number
+    disk_gb          = number
+    storage_pool     = string
+    bridge           = string
+    ip_cidr          = string
+    gateway          = string
+    ci_user          = string
+    ssh_public_key   = string
+    search_domain    = optional(string)
+    nameserver       = optional(string)
+    balloon_mb       = optional(number)
+    start_on_boot    = optional(bool)
+    agent_enabled    = optional(bool)
+  })
+
+  validation {
+    condition     = var.vm.id > 99 && var.vm.id < 1000000000
+    error_message = "vm.id must be a positive non-reserved VMID."
+  }
+
+  validation {
+    condition     = var.vm.cpu_cores >= 1 && var.vm.cpu_sockets >= 1
+    error_message = "cpu_cores and cpu_sockets must both be >= 1."
+  }
+
+  validation {
+    condition     = var.vm.memory_mb >= 512
+    error_message = "memory_mb must be at least 512 MB."
+  }
+
+  validation {
+    condition     = var.vm.disk_gb >= 8
+    error_message = "disk_gb must be at least 8 GB."
+  }
+
+  validation {
+    condition     = can(regex("^[^\\s]+/[0-9]{1,2}$", var.vm.ip_cidr))
+    error_message = "ip_cidr must be in CIDR format, e.g. 192.168.1.10/24."
+  }
+}
+
+variable "snapshot_schedule" {
+  type = object({
+    enabled           = bool
+    minute            = number
+    hour              = number
+    retention         = number
+    ssh_host          = string
+    ssh_port          = optional(number)
+    ssh_user          = string
+    ssh_private_key   = string
+    cron_identifier   = optional(string)
+    snapshot_prefix   = optional(string)
+    snapshot_comment  = optional(string)
+  })
+
+  validation {
+    condition     = var.snapshot_schedule.minute >= 0 && var.snapshot_schedule.minute <= 59
+    error_message = "snapshot_schedule.minute must be between 0 and 59."
+  }
+
+  validation {
+    condition     = var.snapshot_schedule.hour >= 0 && var.snapshot_schedule.hour <= 23
+    error_message = "snapshot_schedule.hour must be between 0 and 23."
+  }
+
+  validation {
+    condition     = var.snapshot_schedule.retention >= 1
+    error_message = "snapshot_schedule.retention must be at least 1."
+  }
+}

--- a/iac/modules/domain-vm-contract/variables.tf
+++ b/iac/modules/domain-vm-contract/variables.tf
@@ -50,19 +50,44 @@ variable "vm" {
   }
 }
 
+variable "ubuntu_template" {
+  type = object({
+    enabled          = bool
+    vmid             = number
+    name             = string
+    storage_pool     = string
+    snippets_storage = optional(string)
+    cloud_image_url  = string
+    ci_user          = string
+    ssh_public_key   = string
+    memory_mb        = optional(number)
+    cpu_cores        = optional(number)
+    cpu_sockets      = optional(number)
+    ssh_host         = string
+    ssh_port         = optional(number)
+    ssh_user         = string
+    ssh_private_key  = string
+  })
+
+  validation {
+    condition     = var.ubuntu_template.vmid > 99
+    error_message = "ubuntu_template.vmid must be greater than 99."
+  }
+}
+
 variable "snapshot_schedule" {
   type = object({
-    enabled           = bool
-    minute            = number
-    hour              = number
-    retention         = number
-    ssh_host          = string
-    ssh_port          = optional(number)
-    ssh_user          = string
-    ssh_private_key   = string
-    cron_identifier   = optional(string)
-    snapshot_prefix   = optional(string)
-    snapshot_comment  = optional(string)
+    enabled          = bool
+    minute           = number
+    hour             = number
+    retention        = number
+    ssh_host         = string
+    ssh_port         = optional(number)
+    ssh_user         = string
+    ssh_private_key  = string
+    cron_identifier  = optional(string)
+    snapshot_prefix  = optional(string)
+    snapshot_comment = optional(string)
   })
 
   validation {

--- a/iac/modules/infrastructure/nightly-snapshot-cron/main.tf
+++ b/iac/modules/infrastructure/nightly-snapshot-cron/main.tf
@@ -1,0 +1,35 @@
+locals {
+  cron_line = "${var.minute} ${var.hour} * * * root /usr/sbin/qm snapshot ${var.vm_id} ${var.snapshot_prefix}-$(date +\\%Y\\%m\\%d-\\%H\\%M) --description '${var.snapshot_comment}' >/dev/null 2>&1; /usr/sbin/qm listsnapshot ${var.vm_id} | awk 'NR>1 {print $1}' | grep '^${var.snapshot_prefix}-' | sort -r | tail -n +$(( ${var.retention} + 1 )) | while read -r snap; do /usr/sbin/qm delsnapshot ${var.vm_id} "$snap" >/dev/null 2>&1; done"
+}
+
+resource "null_resource" "nightly_snapshot_cron" {
+  count = var.enabled ? 1 : 0
+
+  triggers = {
+    cron_identifier  = var.cron_identifier
+    vm_id            = tostring(var.vm_id)
+    minute           = tostring(var.minute)
+    hour             = tostring(var.hour)
+    retention        = tostring(var.retention)
+    snapshot_prefix  = var.snapshot_prefix
+    snapshot_comment = var.snapshot_comment
+  }
+
+  connection {
+    type        = "ssh"
+    host        = var.ssh_host
+    port        = var.ssh_port
+    user        = var.ssh_user
+    private_key = var.ssh_private_key
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "set -euo pipefail",
+      "CRON_FILE=/etc/cron.d/${var.cron_identifier}",
+      "sudo install -m 0644 /dev/null \"$CRON_FILE\"",
+      "echo '${local.cron_line}' | sudo tee \"$CRON_FILE\" >/dev/null",
+      "sudo chmod 0644 \"$CRON_FILE\""
+    ]
+  }
+}

--- a/iac/modules/infrastructure/nightly-snapshot-cron/outputs.tf
+++ b/iac/modules/infrastructure/nightly-snapshot-cron/outputs.tf
@@ -1,0 +1,3 @@
+output "installed" {
+  value = var.enabled
+}

--- a/iac/modules/infrastructure/nightly-snapshot-cron/variables.tf
+++ b/iac/modules/infrastructure/nightly-snapshot-cron/variables.tf
@@ -1,0 +1,12 @@
+variable "enabled" { type = bool }
+variable "minute" { type = number }
+variable "hour" { type = number }
+variable "retention" { type = number }
+variable "vm_id" { type = number }
+variable "ssh_host" { type = string }
+variable "ssh_port" { type = number }
+variable "ssh_user" { type = string }
+variable "ssh_private_key" { type = string }
+variable "cron_identifier" { type = string }
+variable "snapshot_prefix" { type = string }
+variable "snapshot_comment" { type = string }

--- a/iac/modules/infrastructure/proxmox-ubuntu-vm/main.tf
+++ b/iac/modules/infrastructure/proxmox-ubuntu-vm/main.tf
@@ -1,0 +1,42 @@
+resource "proxmox_vm_qemu" "ubuntu" {
+  target_node = var.node_name
+  vmid        = var.vm_id
+  name        = var.vm_name
+
+  clone       = var.template
+  full_clone  = true
+  onboot      = var.start_on_boot
+  agent       = var.agent_enabled ? 1 : 0
+
+  sockets     = var.cpu_sockets
+  cores       = var.cpu_cores
+  memory      = var.memory_mb
+  balloon     = var.balloon_mb
+
+  os_type     = "cloud-init"
+  ciuser      = var.ci_user
+  sshkeys     = var.ssh_public_key
+  ipconfig0   = var.ipconfig0
+  nameserver  = var.nameserver
+  searchdomain = var.search_domain
+
+  scsihw      = "virtio-scsi-pci"
+  bootdisk    = "scsi0"
+
+  disks {
+    scsi {
+      scsi0 {
+        disk {
+          size    = "${var.disk_gb}G"
+          storage = var.storage_pool
+        }
+      }
+    }
+  }
+
+  network {
+    id     = 0
+    model  = "virtio"
+    bridge = var.bridge
+  }
+}

--- a/iac/modules/infrastructure/proxmox-ubuntu-vm/outputs.tf
+++ b/iac/modules/infrastructure/proxmox-ubuntu-vm/outputs.tf
@@ -1,0 +1,7 @@
+output "vm_id" {
+  value = proxmox_vm_qemu.ubuntu.vmid
+}
+
+output "vm_name" {
+  value = proxmox_vm_qemu.ubuntu.name
+}

--- a/iac/modules/infrastructure/proxmox-ubuntu-vm/variables.tf
+++ b/iac/modules/infrastructure/proxmox-ubuntu-vm/variables.tf
@@ -1,0 +1,18 @@
+variable "node_name" { type = string }
+variable "vm_id" { type = number }
+variable "vm_name" { type = string }
+variable "template" { type = string }
+variable "cpu_cores" { type = number }
+variable "cpu_sockets" { type = number }
+variable "memory_mb" { type = number }
+variable "disk_gb" { type = number }
+variable "storage_pool" { type = string }
+variable "bridge" { type = string }
+variable "ci_user" { type = string }
+variable "ssh_public_key" { type = string }
+variable "ipconfig0" { type = string }
+variable "nameserver" { type = string, default = null }
+variable "search_domain" { type = string, default = null }
+variable "balloon_mb" { type = number, default = 0 }
+variable "start_on_boot" { type = bool, default = true }
+variable "agent_enabled" { type = bool, default = true }

--- a/iac/modules/infrastructure/ubuntu-cloud-template/main.tf
+++ b/iac/modules/infrastructure/ubuntu-cloud-template/main.tf
@@ -1,0 +1,42 @@
+locals {
+  image_filename = basename(var.cloud_image_url)
+  image_path     = "/var/lib/vz/template/cache/${local.image_filename}"
+}
+
+resource "null_resource" "ubuntu_cloud_template" {
+  count = var.enabled ? 1 : 0
+
+  triggers = {
+    node_name       = var.node_name
+    template_vmid   = tostring(var.template_vmid)
+    template_name   = var.template_name
+    storage_pool    = var.storage_pool
+    cloud_image_url = var.cloud_image_url
+    ci_user         = var.ci_user
+    ssh_public_key  = var.ssh_public_key
+    memory_mb       = tostring(var.memory_mb)
+    cpu_cores       = tostring(var.cpu_cores)
+    cpu_sockets     = tostring(var.cpu_sockets)
+  }
+
+  connection {
+    type        = "ssh"
+    host        = var.ssh_host
+    port        = var.ssh_port
+    user        = var.ssh_user
+    private_key = var.ssh_private_key
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "set -euo pipefail",
+      "if [ ! -f '${local.image_path}' ]; then sudo wget -O '${local.image_path}' '${var.cloud_image_url}'; fi",
+      "if ! sudo qm status ${var.template_vmid} >/dev/null 2>&1; then sudo qm create ${var.template_vmid} --name ${var.template_name} --memory ${var.memory_mb} --cores ${var.cpu_cores} --sockets ${var.cpu_sockets} --net0 virtio,bridge=vmbr0 --scsihw virtio-scsi-pci; fi",
+      "sudo qm importdisk ${var.template_vmid} '${local.image_path}' ${var.storage_pool} --format qcow2 || true",
+      "if ! sudo qm config ${var.template_vmid} | grep -q '^scsi0:'; then DISK_REF=$(sudo pvesm list ${var.storage_pool} | awk '/vm-${var.template_vmid}-disk-0/ {print $1; exit}'); sudo qm set ${var.template_vmid} --scsi0 \"${var.storage_pool}:$DISK_REF\"; fi",
+      "sudo qm set ${var.template_vmid} --ide2 ${var.storage_pool}:cloudinit --boot c --bootdisk scsi0 --serial0 socket --vga serial0 --agent enabled=1",
+      "sudo qm set ${var.template_vmid} --ciuser '${var.ci_user}' --sshkeys /dev/stdin <<'EOKEY'\n${var.ssh_public_key}\nEOKEY",
+      "sudo qm template ${var.template_vmid}"
+    ]
+  }
+}

--- a/iac/modules/infrastructure/ubuntu-cloud-template/outputs.tf
+++ b/iac/modules/infrastructure/ubuntu-cloud-template/outputs.tf
@@ -1,0 +1,11 @@
+output "template_name" {
+  value = var.template_name
+}
+
+output "template_vmid" {
+  value = var.template_vmid
+}
+
+output "managed" {
+  value = var.enabled
+}

--- a/iac/modules/infrastructure/ubuntu-cloud-template/variables.tf
+++ b/iac/modules/infrastructure/ubuntu-cloud-template/variables.tf
@@ -1,0 +1,16 @@
+variable "enabled" { type = bool }
+variable "node_name" { type = string }
+variable "template_vmid" { type = number }
+variable "template_name" { type = string }
+variable "storage_pool" { type = string }
+variable "cloud_image_url" { type = string }
+variable "snippets_storage" { type = string }
+variable "ci_user" { type = string }
+variable "ssh_public_key" { type = string }
+variable "ssh_host" { type = string }
+variable "ssh_port" { type = number }
+variable "ssh_user" { type = string }
+variable "ssh_private_key" { type = string }
+variable "memory_mb" { type = number }
+variable "cpu_cores" { type = number }
+variable "cpu_sockets" { type = number }

--- a/iac/outputs.tf
+++ b/iac/outputs.tf
@@ -1,0 +1,14 @@
+output "vm_id" {
+  description = "Created Ubuntu VM ID"
+  value       = module.proxmox_node_stack.vm_id
+}
+
+output "vm_name" {
+  description = "Created Ubuntu VM name"
+  value       = module.proxmox_node_stack.vm_name
+}
+
+output "snapshot_cron_installed" {
+  description = "Whether nightly snapshot cron job is configured"
+  value       = module.proxmox_node_stack.snapshot_cron_installed
+}

--- a/iac/outputs.tf
+++ b/iac/outputs.tf
@@ -1,3 +1,13 @@
+output "template_managed" {
+  description = "Whether Ubuntu cloud template is managed by this stack"
+  value       = module.proxmox_node_stack.template_managed
+}
+
+output "template_name" {
+  description = "Ubuntu cloud template used for cloning"
+  value       = module.proxmox_node_stack.template_name
+}
+
 output "vm_id" {
   description = "Created Ubuntu VM ID"
   value       = module.proxmox_node_stack.vm_id

--- a/iac/providers.tf
+++ b/iac/providers.tf
@@ -1,0 +1,8 @@
+provider "proxmox" {
+  pm_api_url          = var.proxmox_api_url
+  pm_api_token_id     = var.proxmox_api_token_id
+  pm_api_token_secret = var.proxmox_api_token_secret
+
+  pm_tls_insecure = var.proxmox_tls_insecure
+  pm_parallel     = 1
+}

--- a/iac/terraform.tfvars.example
+++ b/iac/terraform.tfvars.example
@@ -1,0 +1,45 @@
+proxmox_api_url          = "https://pve.example.com:8006/api2/json"
+proxmox_api_token_id     = "terraform@pve!iac"
+proxmox_api_token_secret = "CHANGE_ME"
+proxmox_tls_insecure     = true
+
+node_name = "pve"
+
+vm = {
+  id             = 2100
+  name           = "ubuntu-prod-01"
+  template       = "ubuntu-24.04-cloudimg-template"
+  cpu_cores      = 4
+  cpu_sockets    = 1
+  memory_mb      = 8192
+  disk_gb        = 80
+  storage_pool   = "local-lvm"
+  bridge         = "vmbr0"
+  ip_cidr        = "192.168.10.40/24"
+  gateway        = "192.168.10.1"
+  ci_user        = "ubuntu"
+  ssh_public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA... you@example"
+  search_domain  = "lab.local"
+  nameserver     = "1.1.1.1"
+  balloon_mb     = 2048
+  start_on_boot  = true
+  agent_enabled  = true
+}
+
+snapshot_schedule = {
+  enabled          = true
+  minute           = 0
+  hour             = 2
+  retention        = 14
+  ssh_host         = "pve.example.com"
+  ssh_port         = 22
+  ssh_user         = "root"
+  ssh_private_key  = <<EOKEY
+-----BEGIN OPENSSH PRIVATE KEY-----
+<private-key-here>
+-----END OPENSSH PRIVATE KEY-----
+EOKEY
+  cron_identifier  = "ubuntu-prod-01-nightly"
+  snapshot_prefix  = "nightly"
+  snapshot_comment = "nightly snapshot via terraform"
+}

--- a/iac/terraform.tfvars.example
+++ b/iac/terraform.tfvars.example
@@ -5,6 +5,28 @@ proxmox_tls_insecure     = true
 
 node_name = "pve"
 
+ubuntu_template = {
+  enabled          = true
+  vmid             = 9000
+  name             = "ubuntu-24.04-cloudimg-template"
+  storage_pool     = "local-lvm"
+  snippets_storage = "local"
+  cloud_image_url  = "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img"
+  ci_user          = "ubuntu"
+  ssh_public_key   = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA... you@example"
+  memory_mb        = 2048
+  cpu_cores        = 2
+  cpu_sockets      = 1
+  ssh_host         = "pve.example.com"
+  ssh_port         = 22
+  ssh_user         = "root"
+  ssh_private_key  = <<EOKEY
+-----BEGIN OPENSSH PRIVATE KEY-----
+<private-key-here>
+-----END OPENSSH PRIVATE KEY-----
+EOKEY
+}
+
 vm = {
   id             = 2100
   name           = "ubuntu-prod-01"

--- a/iac/variables.tf
+++ b/iac/variables.tf
@@ -66,3 +66,25 @@ variable "snapshot_schedule" {
     snapshot_comment  = optional(string)
   })
 }
+
+
+variable "ubuntu_template" {
+  description = "Optional IaC-managed Ubuntu cloud image template used for VM cloning"
+  type = object({
+    enabled          = bool
+    vmid             = number
+    name             = string
+    storage_pool     = string
+    snippets_storage = optional(string)
+    cloud_image_url  = string
+    ci_user          = string
+    ssh_public_key   = string
+    memory_mb        = optional(number)
+    cpu_cores        = optional(number)
+    cpu_sockets      = optional(number)
+    ssh_host         = string
+    ssh_port         = optional(number)
+    ssh_user         = string
+    ssh_private_key  = string
+  })
+}

--- a/iac/variables.tf
+++ b/iac/variables.tf
@@ -1,0 +1,68 @@
+variable "proxmox_api_url" {
+  description = "Proxmox API URL, e.g. https://pve.example.com:8006/api2/json"
+  type        = string
+}
+
+variable "proxmox_api_token_id" {
+  description = "Proxmox API token id in the format user@realm!token"
+  type        = string
+  sensitive   = true
+}
+
+variable "proxmox_api_token_secret" {
+  description = "Proxmox API token secret"
+  type        = string
+  sensitive   = true
+}
+
+variable "proxmox_tls_insecure" {
+  description = "Disable TLS verification for Proxmox API"
+  type        = bool
+  default     = false
+}
+
+variable "node_name" {
+  description = "Target Proxmox node"
+  type        = string
+}
+
+variable "vm" {
+  description = "Ubuntu VM desired state"
+  type = object({
+    id               = number
+    name             = string
+    template         = string
+    cpu_cores        = number
+    cpu_sockets      = number
+    memory_mb        = number
+    disk_gb          = number
+    storage_pool     = string
+    bridge           = string
+    ip_cidr          = string
+    gateway          = string
+    ci_user          = string
+    ssh_public_key   = string
+    search_domain    = optional(string)
+    nameserver       = optional(string)
+    balloon_mb       = optional(number)
+    start_on_boot    = optional(bool)
+    agent_enabled    = optional(bool)
+  })
+}
+
+variable "snapshot_schedule" {
+  description = "Nightly snapshot schedule configuration (UTC)"
+  type = object({
+    enabled           = bool
+    minute            = number
+    hour              = number
+    retention         = number
+    ssh_host          = string
+    ssh_port          = optional(number)
+    ssh_user          = string
+    ssh_private_key   = string
+    cron_identifier   = optional(string)
+    snapshot_prefix   = optional(string)
+    snapshot_comment  = optional(string)
+  })
+}

--- a/iac/versions.tf
+++ b/iac/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    proxmox = {
+      source  = "Telmate/proxmox"
+      version = "~> 3.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.2"
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a complete, runnable IaC stack to manage a Proxmox node, provision an Ubuntu VM from a cloud-image template, and enforce nightly snapshots with retention. 
- Structure the code using an onion-inspired layering model so validation/contract logic is separated from orchestration and provider-specific resources. 

### Description
- Added a new `iac/` composition root with `versions.tf`, `providers.tf`, `variables.tf`, `outputs.tf`, `main.tf`, `terraform.tfvars.example`, and `README.md` to document quick-start and design. 
- Implemented a domain contract module (`modules/domain-vm-contract`) that validates and normalizes VM and snapshot schedule inputs using Terraform `validation` and `locals`. 
- Implemented infrastructure modules: `modules/infrastructure/proxmox-ubuntu-vm` uses the `Telmate/proxmox` provider and `proxmox_vm_qemu` to clone/configure an Ubuntu VM, and `modules/infrastructure/nightly-snapshot-cron` uses a `null_resource` with an SSH `remote-exec` provisioner to install a cron entry that creates timestamped snapshots and prunes older `snapshot_prefix-*` entries. 
- Implemented application composition module (`modules/application/proxmox-node-stack`) that wires the domain contract to infrastructure modules and exposes `vm_id`, `vm_name`, and `snapshot_cron_installed` outputs. 

### Testing
- Attempted to run formatter checks with `terraform fmt -recursive` in the `iac/` folder, but the `terraform` binary is not available in the environment (command not found). 
- Attempted to run OpenTofu formatting with `tofu fmt -recursive`, but the `tofu` binary is not available in the environment (command not found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dac23a02708322af2bfd218860eaa0)